### PR TITLE
refactor: rename HighPerfFractus to Fractus and update related code

### DIFF
--- a/docs/FORMAT.md
+++ b/docs/FORMAT.md
@@ -1,0 +1,73 @@
+# Fractus Wire Format
+
+This file documents the on-disk / on-the-wire binary layout produced by `Fractus`.
+
+Overview
+--------
+Fractus encodes a struct into a compact, deterministic byte sequence. The layout is
+simple and designed for fast encoding/decoding with low allocation overhead.
+
+Top-level layout
+----------------
+All multi-field encodings follow this high-level layout:
+
+1. VarInt: Field count N (number of exported fields present in the struct plan)
+2. Body: Fixed-size fields and variable-length fields concatenated in declaration order.
+
+Notes about fields
+------------------
+- Fixed-size primitives (bool, int8/int16/int32/int64, uint*, float32, float64)
+  are written inline, in little-endian byte order, with no padding between
+  fixed fields. The encoder reuses a small 8-byte scratch buffer to avoid
+  allocating for these writes.
+
+- Variable-length fields (strings, slices) are encoded in the body. Each
+  variable element written to the body is prefixed by a VarInt length and
+  then the payload bytes.
+
+- For slices of fixed-size primitives, Fractus attempts a zero-copy write
+  by appending the backing memory of the slice directly. This is only done
+  when `SafeOptions.UnsafePrimitives` is enabled and the slice is properly
+  aligned (or alignment checks are disabled). Otherwise the slice is encoded
+  element-by-element.
+
+Varint encoding
+---------------
+Fractus uses an LEB128-like unsigned varint for compact lengths and counters.
+Each byte uses the low 7 bits for payload and the high bit as a continuation
+marker.
+
+Unsafe / zero-copy modes
+------------------------
+- `UnsafeStrings`: When enabled, decoded strings may alias the original input
+  buffer. The caller must ensure the input byte slice remains valid (in
+  scope and not modified) for the lifetime of any string values created from
+  it. If this cannot be guaranteed, disable `UnsafeStrings` and Fractus will
+  make safe copies.
+
+- `UnsafePrimitives`: When enabled, Fractus may perform zero-copy conversions
+  of `[]T` to `[]byte` for primitive types. This requires alignment of the
+  slice memory for the element type and is platform-dependent; Fractus
+  performs an alignment check by default and falls back to safe copying if
+  alignment is not satisfied.
+
+Compatibility and evolution
+---------------------------
+The current format is intentionally minimal and stable for a fixed struct
+layout. There is no built-in versioning or schema evolution mechanism yet.
+If you need forward/backward compatibility across different struct layouts
+consider adding an explicit version field to your struct and handling
+compatibility in your application.
+
+Examples
+--------
+For a struct with fields: (Int32, Str, []int16)
+
+- Encoder writes: VarInt(3) then writes fixed Int32 (4 bytes), then writes
+  VarInt(len(Str)) + Str bytes, then VarInt(len(slice)) + slice elements
+  (each 2 bytes little-endian).
+
+This layout keeps decoding fast — fixed fields are read in order and variable
+fields are parsed by reading their length prefixes.
+
+For more examples, see the unit tests and benchmark files.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1,0 +1,73 @@
+# Usage and safety notes
+
+This document gives practical examples for using `Fractus` and the `SafeDecoder`
+wrapper, and highlights caveats when using unsafe zero-copy modes.
+
+Basic encode/decode
+-------------------
+```go
+package main
+
+import (
+    "fmt"
+    "github.com/rawbytedev/fractus"
+)
+
+type Example struct {
+    Name  string
+    Scores []int16
+}
+
+func main() {
+    f := fractus.NewFractus(fractus.SafeOptions{})
+    v := Example{Name: "Alice", Scores: []int16{10,20,30}}
+    data, err := f.Encode(v)
+    if err != nil { panic(err) }
+
+    var out Example
+    if err := f.Decode(data, &out); err != nil { panic(err) }
+    fmt.Println(out)
+}
+```
+
+SafeDecoder example (keep payload alive)
+---------------------------------------
+When `UnsafeStrings` or `UnsafePrimitives` are enabled, decoded values may
+alias the original input buffer. If you need the decoded values to remain
+valid beyond the lifetime of the input byte slice variable, wrap decoding
+with `SafeDecoder` which keeps a reference to the payload:
+
+```go
+f := fractus.NewFractus(fractus.SafeOptions{UnsafeStrings: true})
+data, _ := f.Encode(MyStruct{S: "hello"})
+sd := fractus.NewSafeDecoder(f)
+var out MyStruct
+sd.Decode(data, &out)
+// sd.payload holds onto data ensuring `out.S` remains valid.
+```
+
+Unsafe-mode caveats and best practices
+-------------------------------------
+- `UnsafeStrings`: Decoded strings created via `unsafe.String` will point into
+  the provided input slice. If that slice is modified or freed (goes out of
+  scope and is GC'd), the string becomes invalid. Use `SafeDecoder` when you
+  need the decoded values to outlive the original slice.
+
+- `UnsafePrimitives`: For primitive `[]T` slices, Fractus can avoid copying
+  element bytes by referencing the slice backing memory. This requires proper
+  alignment and is enabled only when `SafeOptions.UnsafePrimitives` is set.
+  If alignment checks fail, Fractus falls back to safe element-by-element
+  encoding/decoding.
+
+- Concurrency: `Fractus` caches per-type metadata safely, but individual
+  `Fractus` instances reuse internal buffers (e.g. `scratch`) and are not
+  safe to share for simultaneous `Encode`/`Decode` calls. Use separate
+  instances per goroutine or add external synchronization.
+
+When to prefer safe mode
+------------------------
+- If you cannot guarantee the lifetime of the input buffer → disable
+  `UnsafeStrings` and `UnsafePrimitives`.
+- If you need maximum performance and can ensure buffer lifetimes and
+  memory alignment → enable unsafe modes and consider `SafeDecoder` where
+  appropriate.

--- a/fractus_bench_test.go
+++ b/fractus_bench_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 )
 
-func BenchmarkFractusZeroAllocs(b *testing.B) {
+func BenchmarkEncode_ZeroAllocs(b *testing.B) {
 	type ZeroAllocs struct{ Int int8 }
 	z := ZeroAllocs{Int: int8(1)}
 	f := NewFractus(SafeOptions{UnsafePrimitives: false})
@@ -14,7 +14,7 @@ func BenchmarkFractusZeroAllocs(b *testing.B) {
 	}
 }
 
-func BenchmarkFractusEncoding(b *testing.B) {
+func BenchmarkEncode_MixedTypes(b *testing.B) {
 	type NewStruct struct {
 		Val      []string
 		Mod      []int8
@@ -33,7 +33,7 @@ func BenchmarkFractusEncoding(b *testing.B) {
 	}
 }
 
-func BenchmarkFractusUnsafeEncoding(b *testing.B) {
+func BenchmarkEncode_MixedTypes_UnsafeStrings(b *testing.B) {
 	type NewStruct struct {
 		Val      []string
 		Mod      []int8
@@ -52,7 +52,7 @@ func BenchmarkFractusUnsafeEncoding(b *testing.B) {
 	}
 }
 
-func BenchmarkFractusDecoding(b *testing.B) {
+func BenchmarkDecode_MixedTypes(b *testing.B) {
 	type NewStruct struct {
 		Val      []string
 		Mod      []int8
@@ -74,7 +74,7 @@ func BenchmarkFractusDecoding(b *testing.B) {
 	}
 }
 
-func BenchmarkFractusUnsafeDecoding(b *testing.B) {
+func BenchmarkDecode_MixedTypes_Unsafe(b *testing.B) {
 	type NewStruct struct {
 		Val      []string
 		Mod      []int8
@@ -95,7 +95,7 @@ func BenchmarkFractusUnsafeDecoding(b *testing.B) {
 	}
 }
 
-func BenchmarkFractusBasic(b *testing.B) {
+func BenchmarkRoundTrip_Primitives(b *testing.B) {
 	type NewStructint struct {
 		Int1 uint8
 		Int2 int8
@@ -116,7 +116,7 @@ func BenchmarkFractusBasic(b *testing.B) {
 	}
 }
 
-func BenchmarkFractusDouble(b *testing.B) {
+func BenchmarkEncode_NoAllocs_Double(b *testing.B) {
 	type NewStructint struct {
 		Int1 uint8
 		Int2 int8
@@ -140,4 +140,17 @@ func BenchmarkFractusDouble(b *testing.B) {
 	}
 	_ = err
 	f.Decode(res, y)
+}
+
+func BenchmarkDecode_WithSafeDecoder(b *testing.B) {
+	type T struct{ S string }
+	f := NewFractus(SafeOptions{UnsafeStrings: true})
+	v := T{S: "bench-payload"}
+	data, _ := f.Encode(v)
+	sd := NewSafeDecoder(f)
+	var out T
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		sd.Decode(data, &out)
+	}
 }

--- a/fractus_bench_test.go
+++ b/fractus_bench_test.go
@@ -1,0 +1,143 @@
+package fractus
+
+import (
+	"testing"
+)
+
+func BenchmarkFractusZeroAllocs(b *testing.B) {
+	type ZeroAllocs struct{ Int int8 }
+	z := ZeroAllocs{Int: int8(1)}
+	f := NewFractus(SafeOptions{UnsafePrimitives: false})
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, _ = f.Encode(z)
+	}
+}
+
+func BenchmarkFractusEncoding(b *testing.B) {
+	type NewStruct struct {
+		Val      []string
+		Mod      []int8
+		Integers []int16
+		Float3   []float32
+		Float6   []float64
+	}
+	Val := []string{"azerty", "hello", "world", "random"}
+	z := NewStruct{Val: Val,
+		Mod: []int8{12, 10, 13, 1}, Integers: []int16{100, 250, 300},
+		Float3: []float32{12.13, 16.23, 75.1}, Float6: []float64{100.5, 165.63, 153.5}}
+	f := NewFractus(SafeOptions{})
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, _ = f.Encode(z)
+	}
+}
+
+func BenchmarkFractusUnsafeEncoding(b *testing.B) {
+	type NewStruct struct {
+		Val      []string
+		Mod      []int8
+		Integers []int16
+		Float3   []float32
+		Float6   []float64
+	}
+	Val := []string{"azerty", "hello", "world", "random"}
+	z := NewStruct{Val: Val,
+		Mod: []int8{12, 10, 13, 0}, Integers: []int16{100, 250, 300},
+		Float3: []float32{12.13, 16.23, 75.1}, Float6: []float64{100.5, 165.63, 153.5}}
+	f := NewFractus(SafeOptions{UnsafePrimitives: false, UnsafeStrings: true})
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, _ = f.Encode(z)
+	}
+}
+
+func BenchmarkFractusDecoding(b *testing.B) {
+	type NewStruct struct {
+		Val      []string
+		Mod      []int8
+		Integers []int16
+		Float3   []float32
+		Float6   []float64
+	}
+	Val := []string{"azerty", "hello", "world", "random"}
+	z := NewStruct{Val: Val,
+		Mod: []int8{12, 10, 13, 0}, Integers: []int16{100, 250, 300},
+		Float3: []float32{12.13, 16.23, 75.1}, Float6: []float64{100.5, 165.63, 153.5}}
+	y := &NewStruct{}
+	f := NewFractus(SafeOptions{UnsafePrimitives: false})
+	s := NewFractus(SafeOptions{UnsafePrimitives: false})
+	b.ReportAllocs()
+	res, _ := f.Encode(z)
+	for i := 0; i < b.N; i++ {
+		s.Decode(res, y)
+	}
+}
+
+func BenchmarkFractusUnsafeDecoding(b *testing.B) {
+	type NewStruct struct {
+		Val      []string
+		Mod      []int8
+		Integers []int16
+		Float3   []float32
+		Float6   []float64
+	}
+	Val := []string{"azerty", "hello", "world", "random"}
+	z := NewStruct{Val: Val,
+		Mod: []int8{12, 10, 13, 0}, Integers: []int16{100, 250, 300},
+		Float3: []float32{12.13, 16.23, 75.1}, Float6: []float64{100.5, 165.63, 153.5}}
+	y := &NewStruct{}
+	f := NewFractus(SafeOptions{UnsafePrimitives: false, UnsafeStrings: true})
+	b.ReportAllocs()
+	res, _ := f.Encode(z)
+	for i := 0; i < b.N; i++ {
+		f.Decode(res, y)
+	}
+}
+
+func BenchmarkFractusBasic(b *testing.B) {
+	type NewStructint struct {
+		Int1 uint8
+		Int2 int8
+		Int3 uint16
+		Int4 int16
+		Int5 uint32
+		Int6 int32
+		Int7 uint64
+		Int9 int64
+	}
+	z := NewStructint{Int1: 1, Int2: 2, Int3: 16, Int4: 18, Int5: 1586, Int6: 15262, Int7: 1547544565, Int9: 15484565656}
+	y := &NewStructint{}
+	f := NewFractus(SafeOptions{})
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		res, _ := f.Encode(z)
+		f.Decode(res, y)
+	}
+}
+
+func BenchmarkFractusDouble(b *testing.B) {
+	type NewStructint struct {
+		Int1 uint8
+		Int2 int8
+		Int3 uint16
+		Int4 int16
+		Int5 uint32
+		Int6 int32
+		Int7 uint64
+		Int9 int64
+	}
+	z := NewStructint{Int1: 1, Int2: 2, Int3: 16, Int4: 18, Int5: 1586, Int6: 15262, Int7: 1547544565, Int9: 15484565656}
+	v := z
+	y := &NewStructint{}
+	f := NewFractus(SafeOptions{})
+	res := []byte{}
+	b.ReportAllocs()
+	_, _ = f.Encode(z)
+	var err error
+	for i := 0; i < b.N; i++ {
+		res, err = f.Encode(v)
+	}
+	_ = err
+	f.Decode(res, y)
+}

--- a/main/main.go
+++ b/main/main.go
@@ -32,7 +32,7 @@ func main() {
 	z := NewStruct{Val: Val,
 		Mod: []int8{12, 10, 13, 0}, Integers: []int16{100, 250, 300},
 		Float3: []float32{12.13, 16.23, 75.1}, Float6: []float64{100.5, 165.63, 153.5}}
-	y := fractus.NewHighPerfFractus(fractus.SafeOptions{UnsafeStrings: true, UnsafePrimitives: true})
+	y := fractus.NewFractus(fractus.SafeOptions{UnsafeStrings: true, UnsafePrimitives: true})
 	for i := 0; i < 10000; i++ {
 		data, _ := y.Encode(z)
 		res := &NewStruct{}

--- a/utils.go
+++ b/utils.go
@@ -21,6 +21,8 @@ func isFixedKind(k reflect.Kind) bool {
 }
 
 func FixedSize(k reflect.Kind) int {
+	// FixedSize returns the byte width for fixed-size primitive kinds.
+	// Returns -1 for non-fixed kinds.
 	switch k {
 	case reflect.Bool, reflect.Int8, reflect.Uint8:
 		return 1
@@ -36,6 +38,7 @@ func FixedSize(k reflect.Kind) int {
 }
 
 func writeVarUint(buf []byte, x uint64) []byte {
+	// writeVarUint appends LEB128-style varint encoding to buf.
 	for x >= 0x80 {
 		buf = append(buf, byte(x)|0x80)
 		x >>= 7
@@ -82,6 +85,8 @@ func setUnsafeFixed(dst reflect.Value, b []byte, k reflect.Kind, sliceLen int) {
 	}
 }
 func setFixed(dst reflect.Value, b []byte, k reflect.Kind) {
+	// setFixed decodes a fixed-size primitive value from b and sets dst.
+	// It expects b to be at least the appropriate width for k.
 	switch k {
 	case reflect.Bool:
 		dst.SetBool(b[0] != 0)
@@ -109,6 +114,9 @@ func setFixed(dst reflect.Value, b []byte, k reflect.Kind) {
 }
 
 func readVarUint(b []byte) (uint64, int) {
+	// readVarUint decodes a varint from the front of b returning the value
+	// and the number of bytes consumed. If b does not contain a full varint,
+	// returns (0, 0).
 	var x uint64
 	var s uint
 	for i, c := range b {


### PR DESCRIPTION
- Updated struct and function names for clarity and consistency.
- Enhanced documentation for encoding/decoding processes.
- Added FORMAT.md to document the wire format.
- Introduced benchmarks for performance evaluation.
- Improved comments for better understanding of the code